### PR TITLE
A few style updates to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Vixi
 
-A "vim like" frontend for [xi-editor](https://github.com/xi-editor/xi-editor).
+A "Vim like" frontend for [xi-editor](https://github.com/xi-editor/xi-editor).
 
 ## Warning
 
@@ -18,7 +18,7 @@ Vim used by 80% of users.
 
 All the keybinding presented below can be overriden via the `keyboard.toml`
 configuration file. You can find an [example of keyboard.toml config](./resources/keyboard.toml)
-which will overrid all the default values with the exact same values.
+which will override all the default values with the exact same values.
 
 Those configuration files should live inside a `vixi` folder placed into the
 OS specific config directory.
@@ -34,7 +34,7 @@ OS specific config directory.
 
 ### Modes
 
-Vixi is behavior is splitted in "modes" (like Vim). Thoses are:
+Vixi behavior is split in "modes" (like Vim). Those are:
 - **Normal** (the default one) used to move and manipulate stuff
 - **Insert** used to insert stuff
 - **Visual** used to select stuff and manipulate it
@@ -42,7 +42,7 @@ Vixi is behavior is splitted in "modes" (like Vim). Thoses are:
 
 At any time you can return to the **Normal** mode by pressing the `Esc` key.
 You can note that the **Action** mode doesn't exists on Vim. This somewhat
-correspond to the Vim `mapLeader` key.
+corresponds to the Vim `mapLeader` key.
 
 
 #### Normal mode
@@ -101,3 +101,4 @@ The Action mode is used to make some generic action like saving or exiting.
 |:-------:|:-------------------:|
 |    q    |         Quit        |
 |    w    | Write into the file |
+


### PR DESCRIPTION
* Made "Vim" capitalization consistent.
* Corrected spelling of "override" (was "overrid")
* Corrected 'Vixi is behavior is splitted in "modes" (like Vim). Thoses
  are:' to 'Vixi behavior is split into "modes" (like Vim). Those are:'
* Re-wrote "You can note that the **Action** mode doesn't exists on
  Vim." as "Note that the **Action** mode doesn't exist in Vim."
* Corrected "This somewhat correspond to..." to "This somewhat
  corresponds to..."