### PR TITLE
input: actions: rpc: handle space keys

### DIFF
--- a/src/input_controller/actions/rpc.rs
+++ b/src/input_controller/actions/rpc.rs
@@ -7,6 +7,7 @@ use xi_rpc::Peer;
 pub fn insert_keystroke(view_id: &str, key: KeyStroke, core: &dyn Peer) -> Response {
     let output = match key {
         KeyStroke::Char(c) => c.to_string(),
+        KeyStroke::KeySpace => ' '.to_string(),
         _ => String::from("<?>"),
     };
 


### PR DESCRIPTION
Space key presses were treated as unknown, and generated prints of
'<?>'.

Signed-off-by: Yotam Ben Dosa <yotambd05@gmail.com>