### PR TITLE
More information for cli

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4,5 +4,9 @@ pub fn build() -> App<'static, 'static> {
     App::new("vixi")
         .version(crate_version!())
         .about(crate_description!())
-        .arg(Arg::with_name("file"))
+        .arg(
+            Arg::with_name("file")
+                .help("The file to open")
+                .required(true),
+        )
 }


### PR DESCRIPTION
I was curious to try this project. But when I ran this editor first time I got useless message:
```
thread 'main' panicked at 'failed to retrieve cli value', src/libcore/option.rs:1185:5
```

This pull request contains a small fix to send a more informative message:

```
error: The following required arguments were not provided:
    <file>

USAGE:
    vixi <file>

For more information try --help
```