### PR TITLE
Add maplit crate for ergonomic hashmap creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -460,6 +460,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "memchr"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1040,6 +1045,7 @@ dependencies = [
  "fern 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1268,6 +1274,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)" = "bedcc7a809076656486ffe045abeeac163da1b558e963a31e29fbfbeba916917"
 "checksum line-wrap 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f30344350a2a51da54c1d53be93fade8a237e545dbcc4bdbe635413f2117cab9"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
+"checksum maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 "checksum memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39"
 "checksum miniz-sys 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "0300eafb20369952951699b68243ab4334f4b10a88f411c221d444b36c40e649"
 "checksum miniz_oxide 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c468f2369f07d651a5d0bb2c9079f8488a66d5466efe42d0c5c6466edcb7f71e"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ serde_json = "1.0"
 termion = "1.5.1"
 toml = "0.5.0"
 backtrace = "0.3"
+maplit = "1.0.2"
 
 [dependencies.clap]
 features = ["suggestions", "color", "wrap_help"]

--- a/src/input_controller/mod.rs
+++ b/src/input_controller/mod.rs
@@ -179,5 +179,4 @@ mod tests {
             config.visual_mode[&String::from("move_down")]
         );
     }
-
 }

--- a/src/input_controller/mode_actions.rs
+++ b/src/input_controller/mode_actions.rs
@@ -39,101 +39,68 @@ impl ModeActions {
 }
 
 pub mod defaults {
+    use maplit::hashmap;
     use std::collections::HashMap;
 
     use super::super::actions::Action;
     use super::super::keyboard::KeyStroke;
 
     lazy_static! {
-        pub static ref DEFAULT_NORMAL_MODE_ACTIONS: HashMap<KeyStroke, Action> = {
-            let mut actions = HashMap::with_capacity(12);
-
-            // The classic arrow keys.
-            actions.insert(KeyStroke::KeyUp, Action::MoveUp);
-            actions.insert(KeyStroke::KeyDown, Action::MoveDown);
-            actions.insert(KeyStroke::KeyLeft, Action::MoveLeft);
-            actions.insert(KeyStroke::KeyRight, Action::MoveRight);
-
-            // The "vim like" keys.
-            actions.insert(KeyStroke::Char('k'), Action::MoveUp);
-            actions.insert(KeyStroke::Char('j'), Action::MoveDown);
-            actions.insert(KeyStroke::Char('h'), Action::MoveLeft);
-            actions.insert(KeyStroke::Char('l'), Action::MoveRight);
-
-            actions.insert(KeyStroke::Char('p'), Action::Paste);
-            actions.insert(KeyStroke::Char('q'), Action::Quite);
-            actions.insert(KeyStroke::Char('i'), Action::SwitchToInsertMode);
-            actions.insert(KeyStroke::Char('v'), Action::SwitchToVisualMode);
-            actions.insert(KeyStroke::KeySpace, Action::SwitchToActionMode);
-
-            actions.insert(KeyStroke::Char('o'), Action::InsertLineBelow);
-            actions.insert(KeyStroke::Char('O'), Action::InsertLineAbove);
-
-            actions.insert(KeyStroke::Char('w'), Action::MoveWordRight);
-            actions.insert(KeyStroke::Char('W'), Action::MoveWordLeft);
-
-            actions.insert(KeyStroke::Char('x'), Action::DeleteForward);
-            actions.insert(KeyStroke::Char('X'), Action::DeleteBackward);
-
-            actions.insert(KeyStroke::Char('>'), Action::Indent);
-            actions.insert(KeyStroke::Char('<'), Action::Outdent);
-
-            actions
+        pub static ref DEFAULT_NORMAL_MODE_ACTIONS: HashMap<KeyStroke, Action> = hashmap! {
+            KeyStroke::KeyUp => Action::MoveUp,
+            KeyStroke::KeyDown => Action::MoveDown,
+            KeyStroke::KeyLeft => Action::MoveLeft,
+            KeyStroke::KeyRight => Action::MoveRight,
+            KeyStroke::Char('k') => Action::MoveUp,
+            KeyStroke::Char('j') => Action::MoveDown,
+            KeyStroke::Char('h') => Action::MoveLeft,
+            KeyStroke::Char('l') => Action::MoveRight,
+            KeyStroke::Char('p') => Action::Paste,
+            KeyStroke::Char('q') => Action::Quite,
+            KeyStroke::Char('i') => Action::SwitchToInsertMode,
+            KeyStroke::Char('v') => Action::SwitchToVisualMode,
+            KeyStroke::KeySpace => Action::SwitchToActionMode,
+            KeyStroke::Char('o') => Action::InsertLineBelow,
+            KeyStroke::Char('O') => Action::InsertLineAbove,
+            KeyStroke::Char('w') => Action::MoveWordRight,
+            KeyStroke::Char('W') => Action::MoveWordLeft,
+            KeyStroke::Char('x') => Action::DeleteForward,
+            KeyStroke::Char('X') => Action::DeleteBackward,
+            KeyStroke::Char('>') => Action::Indent,
+            KeyStroke::Char('<') => Action::Outdent,
         };
-
-        pub static ref DEFAULT_ACTION_MODE_ACTIONS: HashMap<KeyStroke, Action> = {
-            let mut actions = HashMap::with_capacity(3);
-
-            actions.insert(KeyStroke::KeyEscape, Action::SwitchToNormalMode);
-            actions.insert(KeyStroke::Char('q'), Action::Quite);
-            actions.insert(KeyStroke::Char('w'), Action::WriteToFile);
-
-            actions
-    };
-
-        pub static ref DEFAULT_INSERT_MODE_ACTIONS: HashMap<KeyStroke, Action> = {
-            let mut actions = HashMap::with_capacity(12);
-
-            actions.insert(KeyStroke::KeyEscape, Action::SwitchToNormalMode);
-            actions.insert(KeyStroke::KeyBackSpace, Action::DeleteBackward);
-            actions.insert(KeyStroke::KeyDelete, Action::DeleteForward);
-
-            // The classic arrow keys.
-            actions.insert(KeyStroke::KeyUp, Action::MoveUp);
-            actions.insert(KeyStroke::KeyDown, Action::MoveDown);
-            actions.insert(KeyStroke::KeyLeft, Action::MoveLeft);
-            actions.insert(KeyStroke::KeyRight, Action::MoveRight);
-            actions.insert(KeyStroke::KeyPreviousPage, Action::PageUp);
-            actions.insert(KeyStroke::KeyNextPage, Action::PageDown);
-
-            actions
-    };
-
-        pub static ref DEFAULT_VISUAL_MODE_ACTIONS: HashMap<KeyStroke, Action> = {
-            let mut actions = HashMap::with_capacity(1);
-
-            actions.insert(KeyStroke::KeyEscape, Action::SwitchToNormalMode);
-            actions.insert(KeyStroke::Char('q'), Action::SwitchToNormalMode);
-            actions.insert(KeyStroke::Char('y'), Action::YankSelection);
-            actions.insert(KeyStroke::Char('d'), Action::DeleteSelection);
-            actions.insert(KeyStroke::Char('p'), Action::DeleteSelectionAndPaste);
-
-            // The classic arrow keys.
-            actions.insert(KeyStroke::KeyUp, Action::MoveUpAndSelect);
-            actions.insert(KeyStroke::KeyDown, Action::MoveDownAndSelect);
-            actions.insert(KeyStroke::KeyLeft, Action::MoveLeftAndSelect);
-            actions.insert(KeyStroke::KeyRight, Action::MoveRightAndSelect);
-
-            // The "vim like" keys.
-            actions.insert(KeyStroke::Char('k'), Action::MoveUpAndSelect);
-            actions.insert(KeyStroke::Char('j'), Action::MoveDownAndSelect);
-            actions.insert(KeyStroke::Char('h'), Action::MoveLeftAndSelect);
-            actions.insert(KeyStroke::Char('l'), Action::MoveRightAndSelect);
-
-            actions.insert(KeyStroke::Char('w'), Action::MoveWordRightAndSelect);
-            actions.insert(KeyStroke::Char('W'), Action::MoveWordLeftAndSelect);
-
-            actions
-    };
+        pub static ref DEFAULT_ACTION_MODE_ACTIONS: HashMap<KeyStroke, Action> = hashmap! {
+            KeyStroke::KeyEscape => Action::SwitchToNormalMode,
+            KeyStroke::Char('q') => Action::Quite,
+            KeyStroke::Char('w') => Action::WriteToFile,
+        };
+        pub static ref DEFAULT_INSERT_MODE_ACTIONS: HashMap<KeyStroke, Action> = hashmap! {
+            KeyStroke::KeyEscape => Action::SwitchToNormalMode,
+            KeyStroke::KeyBackSpace => Action::DeleteBackward,
+            KeyStroke::KeyDelete => Action::DeleteForward,
+            KeyStroke::KeyUp => Action::MoveUp,
+            KeyStroke::KeyDown => Action::MoveDown,
+            KeyStroke::KeyLeft => Action::MoveLeft,
+            KeyStroke::KeyRight => Action::MoveRight,
+            KeyStroke::KeyPreviousPage => Action::PageUp,
+            KeyStroke::KeyNextPage => Action::PageDown,
+        };
+        pub static ref DEFAULT_VISUAL_MODE_ACTIONS: HashMap<KeyStroke, Action> = hashmap! {
+            KeyStroke::KeyEscape => Action::SwitchToNormalMode,
+            KeyStroke::Char('q') => Action::SwitchToNormalMode,
+            KeyStroke::Char('y') => Action::YankSelection,
+            KeyStroke::Char('d') => Action::DeleteSelection,
+            KeyStroke::Char('p') => Action::DeleteSelectionAndPaste,
+            KeyStroke::KeyUp => Action::MoveUpAndSelect,
+            KeyStroke::KeyDown => Action::MoveDownAndSelect,
+            KeyStroke::KeyLeft => Action::MoveLeftAndSelect,
+            KeyStroke::KeyRight => Action::MoveRightAndSelect,
+            KeyStroke::Char('k') => Action::MoveUpAndSelect,
+            KeyStroke::Char('j') => Action::MoveDownAndSelect,
+            KeyStroke::Char('h') => Action::MoveLeftAndSelect,
+            KeyStroke::Char('l') => Action::MoveRightAndSelect,
+            KeyStroke::Char('w') => Action::MoveWordRightAndSelect,
+            KeyStroke::Char('W') => Action::MoveWordLeftAndSelect,
+        };
     }
 }


### PR DESCRIPTION
I added a tiny crate which makes the code for creating the default key configs much more ergonomic, via the `hashmap!` macro. This way we don't have to update the `with_capacity` number.